### PR TITLE
Adds ssh client to apt install list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get -qqy update \
     wget \
     curl \
     git \
+    ssh \
     jq \
     zip \
     openjdk-8-jre \


### PR DESCRIPTION
Dear Bernhard,
in my setup I use git over ssh. I have added the dependency to the apt install in the base image since it might be helpful in other images as well, and to have it as close as possible to the git definition. Hope that is fine for you, then I would switch to your image. I have a custom one in my repository for now. 
Cheers!